### PR TITLE
Fixed Maven Build Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JavaSnap provides a simple Java interface to the Snapchat API, which has been un
 
 Build a `jar` with Maven using:
 
-    mvn clean compile assembly:assembly
+    mvn clean compile package
 	
 ### Command Line Execution
 Run the `jar` in `target/` with:


### PR DESCRIPTION
The readme was incorrectly telling people to build javasnap with:
    mvn clean compile assembly:assembly

this is not only depricated (assembly:single is now the accepted), but not used after the switch to shade. 

Added correct build command using shade plugin:
    mvn clean compile package
